### PR TITLE
Add client CRUD management

### DIFF
--- a/app/Livewire/Forms/ClientForm.php
+++ b/app/Livewire/Forms/ClientForm.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Livewire\Forms;
+
+use App\Models\Client;
+use Illuminate\Support\Facades\Auth;
+use Livewire\Form;
+
+class ClientForm extends Form
+{
+    public ?Client $client = null;
+
+    public string $first_name = '';
+    public string $last_name = '';
+    public string $email = '';
+    public ?string $phone = null;
+    public ?string $instagram = null;
+
+    protected function rules()
+    {
+        return [
+            'first_name' => ['required', 'string', 'max:255'],
+            'last_name'  => ['required', 'string', 'max:255'],
+            'email'      => ['required', 'email', 'max:255'],
+            'phone'      => ['nullable', 'string', 'max:255'],
+            'instagram'  => ['nullable', 'string', 'max:255'],
+        ];
+    }
+
+    public function setClient(Client $client)
+    {
+        $this->client = $client;
+        $this->first_name = $client->first_name;
+        $this->last_name = $client->last_name;
+        $this->email = $client->email;
+        $this->phone = $client->phone;
+        $this->instagram = $client->instagram;
+    }
+
+    public function store()
+    {
+        $this->validate();
+
+        return Auth::user()->currentTeam->clients()->create([
+            'first_name' => $this->first_name,
+            'last_name'  => $this->last_name,
+            'email'      => $this->email,
+            'phone'      => $this->phone,
+            'instagram'  => $this->instagram,
+        ]);
+    }
+
+    public function update()
+    {
+        $this->validate();
+
+        $this->client->update([
+            'first_name' => $this->first_name,
+            'last_name'  => $this->last_name,
+            'email'      => $this->email,
+            'phone'      => $this->phone,
+            'instagram'  => $this->instagram,
+        ]);
+    }
+}

--- a/app/Models/Client.php
+++ b/app/Models/Client.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Client extends Model
+{
+    /** @use HasFactory<\Database\Factories\ClientFactory> */
+    use HasFactory;
+
+    protected $guarded = [];
+
+    public function team()
+    {
+        return $this->belongsTo(Team::class);
+    }
+}

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -60,6 +60,11 @@ class Team extends Model
         return $this->hasMany(ContractTemplate::class);
     }
 
+    public function clients()
+    {
+        return $this->hasMany(Client::class);
+    }
+
     public function updateBrandLogo(UploadedFile $image)
     {
         tap($this->brand_logo_path, function ($previous) use ($image) {

--- a/database/factories/ClientFactory.php
+++ b/database/factories/ClientFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Client;
+use App\Models\Team;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Client>
+ */
+class ClientFactory extends Factory
+{
+    protected $model = Client::class;
+
+    public function definition(): array
+    {
+        return [
+            'team_id' => Team::factory(),
+            'first_name' => $this->faker->firstName(),
+            'last_name' => $this->faker->lastName(),
+            'email' => $this->faker->safeEmail(),
+            'phone' => $this->faker->phoneNumber(),
+            'instagram' => 'https://instagram.com/'.$this->faker->userName(),
+        ];
+    }
+}

--- a/database/migrations/2025_08_24_174604_create_clients_table.php
+++ b/database/migrations/2025_08_24_174604_create_clients_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use App\Models\Team;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('clients', function (Blueprint $table) {
+            $table->id();
+            $table->foreignIdFor(Team::class)->index();
+            $table->string('first_name');
+            $table->string('last_name');
+            $table->string('email');
+            $table->string('phone')->nullable();
+            $table->string('instagram')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('clients');
+    }
+};

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -51,6 +51,12 @@
                         </flux:navlist.item>
                     </flux:navlist.group>
 
+                    <flux:navlist.group :heading="__('Clients')" class="mt-4">
+                        <flux:navlist.item :href="route('clients')" icon="users">
+                            {{ __('Clients') }}
+                        </flux:navlist.item>
+                    </flux:navlist.group>
+
                     <flux:navlist.group :heading="__('Contracts')" class="mt-4">
                         <flux:navlist.item :href="route('contracts')" icon="document-text">
                             {{ __('Contracts') }}

--- a/resources/views/pages/clients.blade.php
+++ b/resources/views/pages/clients.blade.php
@@ -1,0 +1,164 @@
+<?php
+
+use App\Livewire\Forms\ClientForm;
+use App\Models\Client;
+use Flux\Flux;
+use Livewire\Attributes\Computed;
+use Livewire\Volt\Component;
+use Livewire\WithPagination;
+
+use function Laravel\Folio\middleware;
+use function Laravel\Folio\name;
+
+name('clients');
+
+middleware(['auth', 'verified']);
+
+new class extends Component {
+    use WithPagination;
+
+    public ClientForm $form;
+
+    #[Computed]
+    public function clients()
+    {
+        return auth()->user()->currentTeam->clients()->latest()->paginate(25);
+    }
+
+    public function save()
+    {
+        $this->form->store();
+
+        Flux::modal('create-client')->close();
+        $this->form->reset();
+    }
+
+    public function edit(Client $client)
+    {
+        $this->form->setClient($client);
+
+        Flux::modal('edit-client')->show();
+    }
+
+    public function update()
+    {
+        $this->form->update();
+
+        Flux::modal('edit-client')->close();
+    }
+
+    public function delete(Client $client)
+    {
+        $client->delete();
+    }
+}; ?>
+
+<x-app-layout>
+    @volt('pages.clients')
+        <div>
+            <div class="flex flex-wrap items-end justify-between gap-4">
+                <div class="max-sm:w-full sm:flex-1">
+                    <flux:heading size="xl">{{ __('Clients') }}</flux:heading>
+                    <flux:subheading>{{ __('Manage your clients.') }}</flux:subheading>
+                </div>
+                <div>
+                    <flux:modal.trigger name="create-client">
+                        <flux:button variant="primary">{{ __('Add client') }}</flux:button>
+                    </flux:modal.trigger>
+                </div>
+            </div>
+
+            @if ($this->clients->isNotEmpty())
+                <flux:table id="clients" class="mt-8">
+                    <flux:table.columns>
+                        <flux:table.column>{{ __('Name') }}</flux:table.column>
+                        <flux:table.column>{{ __('Email') }}</flux:table.column>
+                        <flux:table.column>{{ __('Phone') }}</flux:table.column>
+                        <flux:table.column>{{ __('Instagram') }}</flux:table.column>
+                        <flux:table.column></flux:table.column>
+                    </flux:table.columns>
+
+                    <flux:table.rows>
+                        @foreach ($this->clients as $client)
+                            <flux:table.row :key="$client->id">
+                                <flux:table.cell>{{ $client->first_name }} {{ $client->last_name }}</flux:table.cell>
+                                <flux:table.cell>{{ $client->email }}</flux:table.cell>
+                                <flux:table.cell>{{ $client->phone }}</flux:table.cell>
+                                <flux:table.cell>
+                                    @if ($client->instagram)
+                                        <a href="{{ $client->instagram }}" target="_blank" class="text-blue-500 hover:underline">{{ $client->instagram }}</a>
+                                    @endif
+                                </flux:table.cell>
+                                <flux:table.cell>
+                                    <div class="flex gap-2 justify-end">
+                                        <form wire:submit="edit({{ $client->id }})">
+                                            <flux:button type="submit" variant="ghost" size="sm" icon="pencil" inset="top bottom"></flux:button>
+                                        </form>
+                                        <form wire:submit="delete({{ $client->id }})" onsubmit="return confirm('{{ __('Are you sure?') }}');">
+                                            <flux:button type="submit" variant="ghost" size="sm" icon="trash" inset="top bottom"></flux:button>
+                                        </form>
+                                    </div>
+                                </flux:table.cell>
+                            </flux:table.row>
+                        @endforeach
+                    </flux:table.rows>
+                </flux:table>
+
+                <div class="mt-6">
+                    <flux:pagination :paginator="$this->clients" />
+                </div>
+            @else
+                <div class="mt-14 flex flex-1 flex-col items-center justify-center pb-32">
+                    <flux:icon.users class="mb-6 size-12 text-zinc-500 dark:text-white/70" />
+                    <flux:heading size="lg" level="2">{{ __('No clients') }}</flux:heading>
+                    <flux:subheading class="mb-6 max-w-72 text-center">
+                        {{ __('We couldn’t find any clients. Create one to get started.') }}
+                    </flux:subheading>
+                    <flux:modal.trigger name="create-client">
+                        <flux:button variant="primary">{{ __('Add client') }}</flux:button>
+                    </flux:modal.trigger>
+                </div>
+            @endif
+
+            <flux:modal name="create-client" class="w-full sm:max-w-lg">
+                <form wire:submit="save" class="space-y-6">
+                    <div>
+                        <flux:heading size="lg">{{ __('Add a new client') }}</flux:heading>
+                        <flux:subheading>{{ __('Enter the client details.') }}</flux:subheading>
+                    </div>
+
+                    <flux:input wire:model="form.first_name" :label="__('First name')" type="text" />
+                    <flux:input wire:model="form.last_name" :label="__('Last name')" type="text" />
+                    <flux:input wire:model="form.email" :label="__('Email')" type="email" />
+                    <flux:input wire:model="form.phone" :label="__('Phone')" type="text" />
+                    <flux:input wire:model="form.instagram" :label="__('Instagram')" type="text" />
+
+                    <div class="flex">
+                        <flux:spacer />
+                        <flux:button type="submit" variant="primary">{{ __('Save') }}</flux:button>
+                    </div>
+                </form>
+            </flux:modal>
+
+            <flux:modal name="edit-client" class="w-full sm:max-w-lg">
+                <form wire:submit="update" class="space-y-6">
+                    <div>
+                        <flux:heading size="lg">{{ __('Edit client') }}</flux:heading>
+                        <flux:subheading>{{ __('Update the client details.') }}</flux:subheading>
+                    </div>
+
+                    <flux:input wire:model="form.first_name" :label="__('First name')" type="text" />
+                    <flux:input wire:model="form.last_name" :label="__('Last name')" type="text" />
+                    <flux:input wire:model="form.email" :label="__('Email')" type="email" />
+                    <flux:input wire:model="form.phone" :label="__('Phone')" type="text" />
+                    <flux:input wire:model="form.instagram" :label="__('Instagram')" type="text" />
+
+                    <div class="flex">
+                        <flux:spacer />
+                        <flux:button type="submit" variant="primary">{{ __('Save') }}</flux:button>
+                    </div>
+                </form>
+            </flux:modal>
+        </div>
+    @endvolt
+</x-app-layout>


### PR DESCRIPTION
## Summary
- add clients table and model with team relation
- implement Livewire forms and page for client CRUD
- link clients in sidebar navigation

## Testing
- `php artisan test` *(fails: require vendor/autoload.php)*

------
https://chatgpt.com/codex/tasks/task_e_68b468f0d608832eb06dd2804af0d009